### PR TITLE
Always run dist check ci.

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,11 +9,7 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - "**.md"
   pull_request:
-    paths-ignore:
-      - "**.md"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This allows `check-dist` to be a required check for merging.